### PR TITLE
[level02]스킬트리

### DIFF
--- a/programmers/난이도별/level02/스킬트리/HyeonJeong.py
+++ b/programmers/난이도별/level02/스킬트리/HyeonJeong.py
@@ -1,0 +1,13 @@
+def solution(skill, skill_trees):
+    answer = 0
+    slist = [""]*len(skill_trees)
+    for i, x in enumerate(skill_trees):
+        for y in x:
+            if y in skill:
+                slist[i] += y
+    for j in slist:
+        if skill.find(j) == 0:
+            answer += 1
+    return answer
+
+print(solution("CBD", ["BACDE", "CBADF", "AECB", "BDA"])== 2)

--- a/programmers/난이도별/level02/스킬트리/README.md
+++ b/programmers/난이도별/level02/스킬트리/README.md
@@ -1,0 +1,3 @@
+#출처
+
+https://programmers.co.kr/learn/courses/30/lessons/49993


### PR DESCRIPTION
문제 설명

skill : "CBD", skill_trees : ["BACDE", "CBADF", "AECB", "BDA"]  -> return 2

선행 스킬 : 어떤 스킬을 배우기 전에 먼저 배워야 하는 스킬
위 순서에 없는 다른 스킬(힐링 등)은 순서에 상관없이 배울 수 있습니다. 

제한 조건
> 스킬은 알파벳 대문자로 표기하며, 모든 문자열은 알파벳 대문자로만 이루어져 있습니다.
> 스킬 순서와 스킬트리는 문자열로 표기합니다.
> 선행 스킬 순서 skill의 길이는 1 이상 26 이하이며, 스킬은 중복해 주어지지 않습니다.
> skill_trees는 길이가 1 이상 20 이하인 배열이고, 원소는 길이가 2 이상 26 이하인 스킬을 나타내는 문자열이고, 스킬이 중복해 주어지지 않습니다.