### PR TITLE
프로그래머스 더맵게 & 조이스틱

### DIFF
--- a/programmers/난이도별/level02.더 맵게/6047198844.cpp
+++ b/programmers/난이도별/level02.더 맵게/6047198844.cpp
@@ -1,0 +1,38 @@
+#include <string>
+#include <vector>
+#include <queue>
+#include <algorithm>
+#include <iterator>
+#include <iostream>
+
+using namespace std;
+
+int solution(vector<int> scoville, int K) {
+    int answer = 0;
+
+    priority_queue<int, vector<int>, greater<int> > pq;
+    for (int temp : scoville)
+        pq.push(temp);
+    int cnt = 0;
+    int check = pq.top();
+    while (check < K){
+        int first = pq.top(); pq.pop();
+        if (pq.empty()) {
+            if (first < K)
+                return -1;
+            else
+                return cnt;
+        }
+        int second = pq.top(); pq.pop();
+        int mix = first + (second * 2);
+        pq.push(mix);
+        cnt++;
+        check = pq.top();
+    } 
+    answer = cnt;
+    return answer;
+}
+
+int main() {
+    cout << solution({ 0,0,0,0,0,0,0,0,0,0,1,1 }, 7);
+}

--- a/programmers/난이도별/level02.더 맵게/6047198844.cpp
+++ b/programmers/난이도별/level02.더 맵게/6047198844.cpp
@@ -32,7 +32,3 @@ int solution(vector<int> scoville, int K) {
     answer = cnt;
     return answer;
 }
-
-int main() {
-    cout << solution({ 0,0,0,0,0,0,0,0,0,0,1,1 }, 7);
-}

--- a/programmers/난이도별/level02.더 맵게/6047198844.cpp
+++ b/programmers/난이도별/level02.더 맵게/6047198844.cpp
@@ -10,25 +10,17 @@ using namespace std;
 int solution(vector<int> scoville, int K) {
     int answer = 0;
 
-    priority_queue<int, vector<int>, greater<int> > pq;
-    for (int temp : scoville)
-        pq.push(temp);
-    int cnt = 0;
+    priority_queue<int, vector<int>, greater<int> > pq(scoville.begin(), scoville.end());
     int check = pq.top();
-    while (check < K){
+    while (check < K) {
+        if (pq.size() == 1)
+            return -1;
         int first = pq.top(); pq.pop();
-        if (pq.empty()) {
-            if (first < K)
-                return -1;
-            else
-                return cnt;
-        }
         int second = pq.top(); pq.pop();
         int mix = first + (second * 2);
         pq.push(mix);
-        cnt++;
+        answer++;
         check = pq.top();
-    } 
-    answer = cnt;
+    }
     return answer;
 }

--- a/programmers/난이도별/level02.조이스틱/6047198844.cpp
+++ b/programmers/난이도별/level02.조이스틱/6047198844.cpp
@@ -10,12 +10,12 @@ int solution(string name) {
     int left_cursor = name_size - 1;
     int right_cursor = 999999;
     if (name_size >= 2) {
-        //Ä¿¼­¸¦ ¿ŞÂÊÀ¸·Î ÀÌµ¿ÇÏ´Â °æ¿ìÀÇ ¼ö
+        //ì»¤ì„œë¥¼ ì™¼ìª½ìœ¼ë¡œ ì´ë™í•˜ëŠ” ê²½ìš°ì˜ ìˆ˜
         for (int i = 1; name[i] == 'A'&&i<name_size; i++) {
             --left_cursor;
         }
 
-        //Ä¿¼­¸¦ ¿ŞÂÊÀ¸·Î °¬´Ù°¡ ¿À¸¥ÂÊÀ¸·Î ´Ù½Ã ÀÌµ¿ÇÏ´Â °æ¿ìÀÇ¼ö
+        //ì»¤ì„œë¥¼ ì™¼ìª½ìœ¼ë¡œ ê°”ë‹¤ê°€ ì˜¤ë¥¸ìª½ìœ¼ë¡œ ë‹¤ì‹œ ì´ë™í•˜ëŠ” ê²½ìš°ì˜ìˆ˜
         int a_count = 0; int max_a_count = 0; int start_a = 0; int end_a = 0;
         for (int i = 1; i < name_size; i++) {
             if (name[i] == 'A') {
@@ -28,7 +28,7 @@ int solution(string name) {
             }
         }
 
-        ////Ä¿¼­¸¦ ¿À¸¥ÂÊÀ¸·Î ÀÌµ¿ÇÏ´Â °æ¿ìÀÇ ¼ö
+        ////ì»¤ì„œë¥¼ ì˜¤ë¥¸ìª½ìœ¼ë¡œ ì´ë™í•˜ëŠ” ê²½ìš°ì˜ ìˆ˜
         //for (int i = name_size - 1; name[i] == 'A'&&i>0; i--) {
         //    --right_cursor;
         //}
@@ -51,8 +51,4 @@ int solution(string name) {
 
     answer = name_cnt + cursor_cnt;
     return answer;
-}
-
-int main() {
-    cout << solution("ABABAAAAABA");
 }

--- a/programmers/난이도별/level02.조이스틱/6047198844.cpp
+++ b/programmers/난이도별/level02.조이스틱/6047198844.cpp
@@ -1,0 +1,58 @@
+#include <string>
+#include <vector>
+#include <iostream>
+
+using namespace std;
+
+int solution(string name) {
+    int answer = 0;
+    int name_size = name.size();
+    int left_cursor = name_size - 1;
+    int right_cursor = 999999;
+    if (name_size >= 2) {
+        //커서를 왼쪽으로 이동하는 경우의 수
+        for (int i = 1; name[i] == 'A'&&i<name_size; i++) {
+            --left_cursor;
+        }
+
+        //커서를 왼쪽으로 갔다가 오른쪽으로 다시 이동하는 경우의수
+        int a_count = 0; int max_a_count = 0; int start_a = 0; int end_a = 0;
+        for (int i = 1; i < name_size; i++) {
+            if (name[i] == 'A') {
+                start_a = i;
+                for (; name[i] == 'A' && i < name_size; i++);
+                end_a = i;
+                int temp = (start_a - 1) * 2 + (name_size - end_a);
+                if (temp < right_cursor || right_cursor == -1)
+                    right_cursor = temp;
+            }
+        }
+
+        ////커서를 오른쪽으로 이동하는 경우의 수
+        //for (int i = name_size - 1; name[i] == 'A'&&i>0; i--) {
+        //    --right_cursor;
+        //}
+
+
+    }
+    int cursor_cnt = left_cursor > right_cursor ? right_cursor : left_cursor;
+
+    int name_cnt = 0;
+    int up_cursor;
+    int down_cursor;
+    for (auto i : name) {
+        up_cursor = 'Z' - i + 1;
+        down_cursor = i - 'A';
+        if (up_cursor > down_cursor)
+            name_cnt += down_cursor;
+        else
+            name_cnt += up_cursor;
+    }
+
+    answer = name_cnt + cursor_cnt;
+    return answer;
+}
+
+int main() {
+    cout << solution("ABABAAAAABA");
+}


### PR DESCRIPTION
더 맵게
**1**
출처 : https://programmers.co.kr/learn/courses/30/lessons/42626
**2**
input : 스코빌 지수를 담은 배열
output : 모든 음식의 스코빌 지수를 K 이상으로 만들기 위해 섞어야하는 최소 횟수
**3**
풀이 아이디어
섞은 음식의 스코빌 지수 = 가장 맵지 않은 음식의 스코빌 지수 + (두 번째로 맵지 않은 음식의 스코빌 지수 * 2) 가 이 문제에서 제시한 공식입니다. 처음에는 두개의 음식을 섞고 넣은 뒤 정렬하는식으로 전부 K이상이 될때까지 반복하려하였으나.. scoville의 길이(최대 1,000,000)를 보고 생각을 접었습니다. priority_queue를 이용하면 logn에 삽입을 할수있고 자동으로 정렬까지 해주기 때문에 priority_queue를 이용해야겠다고 생각했습니다.

구현은 어렵지 않습니다. 공식과 priority_queue를 이용합니다. priority_queue의 맨앞과 그 다음 값을 섞은 뒤 값을 계산해서 push합니다. 섞을때마다 answer값을 늘립니다. 섞어야하는 최소횟수를 구하는 것이니까요.
priority_queue의 size가 1이 됬는데도 K값에 도달하지 못했다면 그건 만들수없는겁니다. 따라서 -1을 반환합니다.

조이스틱
**1**
출처 : https://programmers.co.kr/learn/courses/30/lessons/42860
**2**
input : 완성해야 하는 이름
output : 조이스틱을 움직인 최소 횟수
**3**
풀이 아이디어 : 이 문제는 특이 합니다. 보통의 문제라면 마지막 위치에서 오른쪽으로 이동한다면 첫번째 문자에 커서가 갔을탠데, 이 문제는 첫 번째 위치에서 왼쪽으로 이동할 경우만 고려대상입니다. 즉 마지막 위치에서 오른쪽으로 이동이 되지않습니다.

먼저 좌/우 커서에 대해서 고려합니다.
두가지 경우의 수로 풀었습니다. 두가지 경우의 수 중 작은 경우의 수가 좌우로 움직이는 최소값입니다.
1. 커서를 왼쪽으로만 이동하는 수(오른쪽으로만 이동해도 됩니다)
2. 커서를 오른쪽으로 이동하다가 "A"를 만나면 왼쪽으로 이동하는 수
3. 하지만 커서를 왼쪽으로 이동하다가 "A"를 만나면 오른쪽으로 이동하는 수는 없습니다.

예를 들면서 위의 경우의 수를 설명하겠습니다.
BBAAABBB를 예를 들어 설명하자면 
1의 경우 
<-<---------
  BBAAABBB
이므로 7번 이동해야 합니다.

반면 2의 경우
  ->
  <-
             <--
  BBAAABBB   
이므로 5번 이동해야합니다.

3번의 경우
<-       
             <--
             ---> (여기서 막힙니다. 따라서 2번째 B가 수정되지 못하였으므로 경우의수에서 제외됩니다.)
  BBAAABBB

좌우의 경우의 수를 구하고 둘중 최소값을 구합니다.

이제 각각의 모든 문자에 대해서 상/하 커서의 최소값을 구합니다.

두가지 경우의 수가 있습니다. (변수명이 반대로 됬네요)
1. 위커서를 연속하여 올리는 경우의 수(다음 알파벳) ==> 문자 - 'A'
2. 아래커서를 연속하여 누르는 경우의 수(이전 알파벳) ==> 'Z' - 문자 + 1
이 이외의 수는 중복을 발생시키므로 무조건 최소값을 만들지 못합니다.

문자 C를 예를 들면(초기버튼은 A부터 시작됩니다)
1의 경우 'C' - 'A' 이므로 2가 됩니다.  위버튼 2번을 누르면 C가 됩니다.
2의 경우 'Z' - 'C' + 1 이므로 24가 됩니다. 아래버튼 24번을 누르면 C가됩니다.

C의 경우 위버튼을 연속해서 누르는것이 더 이득입니다. 따라서 위아래 최소값에 1을 더합니다.
이런식으로 주어진 문자열의 모든 위/아래값을 다 따져보고 최종 최소값을 구합니다.

좌/우 커서의 최소값과 상/하 커서의 최소값의 합이 최종 답입니다.

코드리뷰 항상 감사드립니다.



