### PR TITLE
BOJ 9465. 스티커

### DIFF
--- a/BOJ/9465.스티커/Munang.py
+++ b/BOJ/9465.스티커/Munang.py
@@ -1,5 +1,3 @@
-## dp 문제 
-
 t = int(input())
 
 for i in range(t):


### PR DESCRIPTION
1. 백준 알고리즘 9465 스티커 입니다.
https://www.acmicpc.net/problem/9465

2. input
- 테스트 케이스
- 스티커의 (세로) 열 개수
- 각 스티커 칸의 점수 (2* 스티커의 열 개수)

3. 풀이 아이디어
intro)

- 반드시 첫 번째(혹은 n번째)는 이래야 한다 ! 라는 명확성이 필요하다고 생각합니다. ( 이걸 아는데 이 문제로만 2주 넘게 걸렸습니다.. )
- 본 문제에서는 반드시 떼어져야만 하는 스티커의 규칙을 알아야 합니다.
- 그리고 이 명확성을 기반으로 일반화를 할 줄 알아야 문제를 풀 수 있다고 생각합니다.

1)
- 이 문제에서의 아이디어는 임의의 스티커를 뗀다고 하면, 그 이전에 반드시 떼어져야 하는 스티커가 무엇인지 생각하는 것 입니다.
- 예를들어, 
![image](https://user-images.githubusercontent.com/50222189/99079921-edb8ca00-2603-11eb-8e93-49bfafaf6878.png)
다음과 같이 20의 스티커가 떼어졌다고 하면 그 이전에 70 혹은 50이 반드시 떼어졌어야 합니다.
![image](https://user-images.githubusercontent.com/50222189/99080041-117c1000-2604-11eb-9b6a-30779ac9780c.png)

2) 
1)의 생각을 바탕으로 일반항을 세워보면 다음과 같습니다. (dp는 스티커 점수의 리스트이고, memo는 각 리스트 원소의 스티커를 떼었을때 이전까지 떼어졌던 스티커들의 합을 더한 리스트입니다.)
        memo[0][k] = max(memo[1][k-1], memo[1][k-2]) + dp[0][k]
        memo[1][k] = max(memo[0][k-1], memo[0][k-2]) + dp[1][k]

3) 
basecase로 k==1일때와 k==0일때는 별도로 지정하여 Bottom up방식으로 풀이했습니다.
        if(k ==0):
            memo[0][k] = dp[0][k]
            memo[1][k] = dp[1][k]
        if(k ==1):
            memo[1][1] = dp[0][0] + dp[1][1]
            memo[0][1] = dp[1][0] + dp[0][1]


