### PR TITLE
[Backtracking] Subsets

### DIFF
--- a/LeetCode/Backtracking/Subsets/JeongShin.js
+++ b/LeetCode/Backtracking/Subsets/JeongShin.js
@@ -1,0 +1,22 @@
+/**
+ * @param {number[]} nums
+ * @return {number[][]}
+ */
+const subsets = function (nums) {
+    const answer = [];
+    backtracking(nums, [], 0, nums.length, answer);
+    console.log(answer)
+    return answer;
+};
+
+function backtracking(nums, subset, start, target, answer) {
+    for (let i = start; i < target; i++) {
+        subset.push(nums[i]);
+        backtracking(nums, [...subset], i + 1, target, answer);
+        subset.pop();
+    }
+    answer.push([...subset]);
+}
+
+subsets([1, 2, 2]);
+

--- a/LeetCode/String/Group_Anagrams/JeongShin.js
+++ b/LeetCode/String/Group_Anagrams/JeongShin.js
@@ -1,0 +1,27 @@
+/**
+ * @param {string[]} strings
+ * @return {string[][]}
+ */
+const groupAnagrams = function (strings) {
+    const answer = [];
+    const map = new Map();
+    const charOffSet = "a".charCodeAt(0);
+
+    for (const string of strings) {
+        const charCount = new Array(26).fill(0);
+        for (const char of string)
+            charCount[char.charCodeAt(0) - charOffSet]++;
+        const val = charCount.join(",");
+        let index;
+        // index 가 0 인 경우 고려하여 undefined 와 비교
+        if ((index = map.get(val)) !== undefined) {
+            answer[index].push(string);
+            continue;
+        }
+        map.set(val, index = answer.length);
+        answer[index] = [string];
+    }
+    return answer;
+};
+
+


### PR DESCRIPTION
# Backtracking Subsets
https://leetcode.com/problems/subsets/ 

```js
nums = [1,2,3]
//  [[],[1],[2],[1,2],[3],[1,3],[2,3],[1,2,3]]
```
과 같이 배열이 있을때 가능한 모든 subset 을 구하는 문제 입니다. 
이 문제는 중복을 허용하기 때문에 backtracking 방법으로 풀이가 가능했습니다. 

순열, 조합 등의 문제는 주기적으로 풀어야 잘 안 까먹는거 같습니다 ㅎㅎ ,,, 😅

# Group Anagrams

한 문제를 더 풀이하게 될 줄 모르고 브랜치 생성하지 않고 그냥 pr 을 올려서 어쩔 수 없이 두 문제 pr 이 되었습니다. 

https://leetcode.com/problems/group-anagrams/

```js 
strs = ["eat","tea","tan","ate","nat","bat"] 
// output : [["bat"],["nat","tan"],["ate","eat","tea"]]
```

과 같이 문자가 담긴 배열이 있을때 anagrams 끼리 묶는 문제 입니다. 
anagrams 기준은 같은 문자를 포함하면 anagram 이 됩니다. 
다양한 방법으로 쉽게 풀이 할 수 있지만 최대한 효율성을 고려하여 풀이 해보았습니다. 
sorting 비용이 가장 클거 같아서 sorting 을 사용하지 않고 알파벳 개수만 count 해서 string 으로 join 하여 Map에  같은 anagrams 의 answer 배열에서 위치 (인덱스)를 저장해두어 풀이 하였습니다.  

