### PR TITLE
[Tree] Path Sum III 풀이

### DIFF
--- a/LeetCode/Tree/Path_Sum_III/JeongShin.js
+++ b/LeetCode/Tree/Path_Sum_III/JeongShin.js
@@ -1,0 +1,36 @@
+/**
+ * Definition for a binary tree node.
+ * function TreeNode(val, left, right) {
+ *     this.val = (val===undefined ? 0 : val)
+ *     this.left = (left===undefined ? null : left)
+ *     this.right = (right===undefined ? null : right)
+ * }
+ */
+/**
+ * @param {number[]} root
+ * @param {number} sum
+ * @return {number}
+ */
+const pathSum = function (root, sum) {
+  const memo = { 0: 1 };
+  const self = this;
+  self.answer = 0;
+  dfs.call(self, root, sum, 0, memo);
+  return self.answer;
+};
+
+function dfs(node, target, currSum, memo) {
+  if (!node)
+    return;
+
+  currSum += node.val;
+
+  this.answer += (memo[currSum - target] || 0);
+  memo[currSum] = (memo[currSum] || 0) + 1;
+
+  dfs.call(this, node.left, target, currSum, memo);
+  dfs.call(this, node.right, target, currSum, memo);
+
+  memo[currSum]--;
+}
+


### PR DESCRIPTION
# [Tree] Path Sum III 

https://leetcode.com/problems/path-sum-iii/

```js
root = [10,5,-3,3,2,null,11,3,-2,null,1], sum = 8
```

다음과 같이 트리 구조에서 아래로 탐색을 하면서 sum 을 만들수 있는 경우의 수를 반환하는 문제 입니다. 
예제의 경우
1. path: 5 -> 3
2. path: 5 -> 2 -> 1
3. path: -3 -> 11 
즉, 3을 반환해야 합니다. 

이 문제의 어려웠던 점은 기존에 지나온 sum 들에 대한 데이터를 보관하면서 문제 풀이를 접근 해야 합니다. 
예를들어, target 이 12라 가정

트리 노드를 탐색 도중
```
         Node  <- 여기 node 까지 오는 방법의 수 : 3, sum : 10 
        /      \    
    Node     Node  <- value : 2 라고 가정하면 
```
오른쪽 자식이 target 12 를 만족하기 때문에 이전 path 까지 오는 방법의 수 3을 모두 고려해줘야 합니다. 

또한 이 문제의 경우 루트부터 지나온 모든 sum 뿐만 아니라 subtree 에 해당 되는 path 까지 답에 포함되기 때문에 

1. 현재 sum의 빈도를 memo
2. sum - target 의 빈도를 answer 에 add (현재 sum을 유지하면서 subtree에 해당 되는 pathSum 의 빈도를 구할 수 있음) -> 이 부분이 가장 어려웠습니다 ㅜㅜ.
3. 모든 자식 노드 탐색
4. 현재 sum --; -> 현재 노드가 탐색을 마쳤기 때문에 해당 sum 은 이제 제외 시켜줘야함

의 방법으로 풀이하였습니다. 
생각보다 까다로워서 풀이를 참고해봤는데 풀이도 한참 고민해봤던거 같네요.. 

추가로 dfs 내부함수에서 answer를 적당하게 리턴해주기 까다롭게 느껴줘서 그냥 this에 바인딩 시켜서 함수 호출하여 풀이 했는데 그닥 좋은 방법은 아닌거 같습니다... 