### PR TITLE
[구현]큰 수 A+B / [다익스트라]특정한 최단 경로

### DIFF
--- a/BOJ/10757.큰 수 A+B/6047198844.cpp
+++ b/BOJ/10757.큰 수 A+B/6047198844.cpp
@@ -1,0 +1,28 @@
+#include <iostream>
+#include <string>
+
+using namespace std;
+
+int main() {
+	string a;
+	string b;
+	cin >> a >> b;
+	while (a.length() != b.length()) {
+		if (a.length() > b.length())
+			b = '0' + b;
+		else if (a.length() < b.length())
+			a = '0' + a;
+	}
+	string res = "";
+	int temp = 0;
+	int aIdx = a.length() - 1, bIdx = b.length() - 1;
+	for (; aIdx >= 0 && bIdx >= 0; aIdx--, bIdx--) {
+		int digit = temp + a[aIdx] + b[bIdx] - 2*'0';
+		temp = digit / 10;
+		digit %= 10;
+		res = char(digit + '0') + res;
+	}
+	if(temp)
+		res = char(temp + '0') + res;
+	cout << res;
+}

--- a/BOJ/1504.특정한 최단 경로/6047198844.cpp
+++ b/BOJ/1504.특정한 최단 경로/6047198844.cpp
@@ -1,0 +1,61 @@
+#include <iostream>
+#include <vector>
+#include <queue>
+#include <cstring>
+#include <climits>
+#define INF 987654321
+using namespace std;
+
+
+vector <pair< int,int > > graph[801];
+
+vector <int> dijkstra(int N,int v) {
+	vector <int> dest(N + 1, INF);
+	priority_queue <pair<int, int> > pq;
+	pq.push({ 0,v });
+	dest[v] = 0;
+	while (!pq.empty()) {
+		int cost = -pq.top().first;
+		int here = pq.top().second;
+		pq.pop();
+		if (cost > dest[here])
+			continue;
+		for (auto node : graph[here]) {
+			if (dest[node.first] > cost + node.second) {
+				dest[node.first] = cost + node.second;
+				pq.push({ -dest[node.first], node.first });
+			}
+		}
+	}
+	return dest;
+}
+
+int main() {
+	int N, E;
+	cin >> N >> E;
+	int a, b, c;
+	while (E--) {
+		cin >> a >> b >> c;
+		graph[a].push_back({ b,c });
+		graph[b].push_back({ a,c });
+	}
+	int v1, v2;
+	cin >> v1 >> v2;
+
+	vector <int> start_di = dijkstra(N, 1);
+	vector <int> dist_v1 = dijkstra(N, v1);
+	vector <int> dist_v2 = dijkstra(N, v2);
+	//오버플로우.
+	int cnt = INF;
+	int res;
+	// 1 -> v1 -> v2 -> N
+	// 1 -> v2 -> v1 -> N
+
+	res = min(start_di[v1] + dist_v1[v2] + dist_v2[N], start_di[v2] + dist_v2[v1] + dist_v1[N]);
+	if (res < INF && res > 0)
+		cout << res;
+	else
+		cout << "-1";
+}
+
+//edge가 반드시 최저라는 보장이 없다.


### PR DESCRIPTION
**1**
출처 : 백준

**2**
input : 두개의 큰 수
output : 두개의 큰 수를 더한 값
**3**
풀이 아이디어
C++이 저장할수있는 수의 범위를 넘어서 int로 받을수가없습니다.
우선, 두개의 숫자를 string으로 받고, 짧은 길이의 string 앞에 0을 붙이는 식으로 해당 string의 길이를 동일하게 맞춰주었습니다.
그 후 뒤에서 부터 더했습니다. 올림이 있을경우에는, 해당 올림을 저장하고 나머지를 답에 더했습니다.

예를 들면 12345 123의 경우
12349 00123으로 먼저 길이를 맞추어 주었습니다.
뒤에서 부터 더해줍니다.
9+3 은 12입니다. 따라서 1의 올림이 있습니다. 해당 올림을 저장하고 나머지는 답에 붙입니다.
현재 답은 2입니다.
4와 2, 그리고 이전의 올림 1을 더합니다. 7입니다. 이번에는 올림수를 0으로 설정합니다. 나머지는 답에 붙입니다.
현재 답은 72입니다.
같은 방식으로 문자열 끝까지 진행합니다. 마지막에 올림이 있을 경우도 체크해주어야 하네요.

**1**
출처 : 백준
https://www.acmicpc.net/problem/1504

**2**
input : 간선
output : 경로
**3**
풀이 아이디어
일반 다익스트라입니다.
하지만 
1 -> v1 -> v2 -> N의 경우와
1 -> v2 -> v1 -> N의 경우를 따져야합니다.
v1 -> v2  / v2 -> v1 이 경우를 그냥 두 점을 잇는 간선이라고 생각했는데.
**두 점을 잇는 간선이 반드시 최단거리는 아니다 라는 점을** 생각하지 못했네요.