### PR TITLE
[Greedy]설탕 배달

### DIFF
--- a/BOJ/2839.설탕 배달/pul8219.js
+++ b/BOJ/2839.설탕 배달/pul8219.js
@@ -1,0 +1,26 @@
+// BOJ
+// 2389번 문제: 설탕 배달
+
+var n = Number(require('fs').readFileSync('/dev/stdin')); // BOJ 제출용 코드. 입력값을 받는 코드이며 입력값을 숫자로 받기 위해 Number로 감쌈 // 초기 n은 봉지에 나눠담을 설탕 n킬로그램을 의미
+
+let three = 0; // 3kg짜리 봉지 개수
+let five = Math.floor(n / 5); // 5kg짜리 봉지 개수
+n %= 5;
+
+while(five >= 0){
+    if(n % 3 == 0){ // 5kg 봉지에 담고 남은 나머지 설탕의 무게가 3kg 봉지에 딱 나눠떨어지게 담긴다면
+        three = Math.floor(n / 3); // 3kg짜리 봉지 개수 갱신
+        n %= 3; // n은 0일 것 // 봉지에 담아야할 설탕을 모두 담았음
+        break;
+
+    }
+    five--; // 5kg 봉지에 담고 남은 나머지 설탕의 무게가 3kg 봉지에 딱 떨어지게 담길 수 없다면 five를 감소시킴(5kg 짜리 봉지수를 한 개 감소시키는 것)
+    n += 5; // 5kg 봉지를 감소시켰으니 남은 설탕의 무게도 +5 해줌
+}
+
+if (n==0){ // 봉지에 모두 잘 담겼다면
+    console.log(five + three); // 봉지개수 출력
+}
+else{ // 정확하게 N킬로그램을 만들 수 없다면
+    console.log(-1); // -1 출력
+}


### PR DESCRIPTION
- 문제 출처: https://www.acmicpc.net/problem/2839
- 문제 설명: 배달해야할 설탕의 무게 n을 양의 정수를 입력받아 5kg, 3kg짜리 봉지에 나눠담는데 봉지를 최대한 적게 사용하는 것이 목표인 문제입니다. 총 사용한 봉지 개수를 출력하고, N킬로그램의 설탕을 5kg, 3kg로 딱 나눠 담을 수 없을 경우엔 -1을 출력합니다.
- 풀이 아이디어: 봉지를 적게 사용하는 것이 목표이기 때문에 5kg 봉지를 최대한 많이 사용해야합니다. 처음엔 5kg봉지로 나누어담고 3kg로 나누어담는데 딱 떨어지지 않으면 바로 -1을 출력하는 참 대단한^^ 생각으로 문제를 풀었습니다. 이렇게 푸는게 아니라 5kg 봉지수를 줄여가면서 그 순간순간 최적해를 찾아야하더라고요 당연한걸 순간 간과했네요; 이게 그리디 알고리즘 개념 맞겠죠?!

알고리즘 손 놓고 있다가 이대론 계속 집에만 있겠다싶어 정말 오랜만에 알고리즘을 풀이했습니다. 대표적인 알고리즘 위주로 많이 못 풀어도 꾸준히 풀며 기본기를 잡아야겠단생각인데, 아직 부족한 실력이지만 리뷰도 많이 남겨보겠습니다! 이전에 썼던 java말고 js로 앞으로 풀이해볼 생각인데 js로 백준은 많이 불편하네요 릿코드나 프로그래머스를 이용해봐야겠습니다. 왜 갑자기 이렇게 긴 사족을 남기는지 저도 모르겠지만...ㅋㅋㅋㅋㅋ 보시는 분들 계시다면 2021도 힘내서 공부해봅시다 아자아자
