### PR TITLE
[분할정복]피보나치수 6

### DIFF
--- a/BOJ/11444.피보나치 수 6/11444_피보나치 수 6.cpp
+++ b/BOJ/11444.피보나치 수 6/11444_피보나치 수 6.cpp
@@ -1,0 +1,39 @@
+#include <iostream>
+#include <vector>
+#define LL vector<long long>
+
+using namespace std;
+vector <LL> vt({ LL({1,1}),LL({1,0}) });
+
+vector <LL> multiply_matrix(vector <LL> A, vector <LL> B) {
+	vector <LL> res({
+		LL({
+			(A[0][0] % 1000000007 * B[0][0] % 1000000007 + A[0][1] % 1000000007 * B[1][0] % 1000000007) % 1000000007,
+			(A[0][0] % 1000000007 * B[0][1] % 1000000007 + A[0][1] % 1000000007 * B[1][1] % 1000000007) % 1000000007}),
+		LL({
+			(A[1][0] % 1000000007 * B[0][0] % 1000000007 + A[1][1] % 1000000007 * B[1][0] % 1000000007) % 1000000007,
+			(A[1][0] % 1000000007 * B[0][1] % 1000000007 + A[1][1] % 1000000007 * B[1][1] % 1000000007) % 1000000007}) });
+	return res;
+}
+
+vector <LL> divide_and_conquer(long long n) {
+	if (n == 1)
+		return vt;
+	vector <LL> res = divide_and_conquer(n / 2);
+	vector <LL> square_res = multiply_matrix(res, res);
+	//n이 2로 안나누어질때, 홀수일때
+	if (n % 2)
+		return multiply_matrix(square_res, vt);
+	return square_res;
+}
+
+int main() {
+	long long n;
+	cin >> n;
+	if (n == 0) {
+		cout << "0";
+		return 0;
+	}
+	vector <LL> res = divide_and_conquer(n);
+	cout << res[0][1] % 1000000007;
+}


### PR DESCRIPTION
**1**
출처 : 백준
https://www.acmicpc.net/problem/11444

**2**
input : N
output : 피보나치수 N

**3**
풀이 아이디어
우선 N이 엄청 큽니다. 일반 피보나치 수열로는 풀수없습니다. 이 문제는 고민하다가 답을 봤습니다. 분할 정복으로 풀어야하는 문제입니다.

기본행렬을
Fn+1 Fn
Fn Fn-1
로 잡고 행렬의 제곱을 통해서 구하면 됩니다. 예를 들어 기본 행렬의 3제곱을 하면. Fn 자리에 있는 값이 F3값이고, 5제곱을 하면 Fn 자리에 있는 값이 F5입니다.