### PR TITLE
[분할정복]히스토그램 / [다익스트라]최소비용구하기

### DIFF
--- a/BOJ/1725.히스토그램/1725_히스토그램.cpp
+++ b/BOJ/1725.히스토그램/1725_히스토그램.cpp
@@ -1,0 +1,50 @@
+#include <iostream>
+#include <algorithm>
+#include <vector>
+
+using namespace std;
+
+//index start부터 index end까지의 직사각형중 가장 넒이가 큰 직사각형을 구한다.
+int divide_and_conquer(int start, int end,vector <int> &fence) {
+	if (start == end)
+		return fence[start];
+
+	//3가지 경우로 divide한다.
+	//직사각형이 중앙을 걸치지 않고 왼쪽에 있는 경우
+	//직사각형이 중앙을 걸치는 경우
+	//직사각형이 중앙을 걸치지 않고 오른쪽에 있는 경우
+	int mid = (start + end) / 2;
+	int left_side = divide_and_conquer(start, mid, fence);
+	int right_side = divide_and_conquer(mid + 1, end, fence);
+	int res = max(left_side, right_side);
+	int left_index = mid;
+	int right_index = mid + 1;
+	int height = min(fence[left_index], fence[right_index]);
+	res = max(res, height * 2);
+	while (left_index > start || right_index < end) {
+		//left_index를 감소시키는 경우, 좌 우를 살피는것임.
+		if ((right_index == end)||left_index > start && fence[left_index-1] > fence[right_index+1]) {
+			--left_index;
+			height = min(height, fence[left_index]);
+		}
+		//right_index를 증가시키는 경우
+		else {
+			++right_index;
+			height = min(height, fence[right_index]);
+		}
+		res = max(res, height * (right_index - left_index + 1));
+	}
+	return res;
+}
+
+int main() {
+	int N;
+	cin >> N;
+	vector <int> fence;
+	int num;
+	for (int i = 0; i < N; i++) {
+		cin >> num;
+		fence.push_back(num);
+	}
+	cout << divide_and_conquer(0, N - 1, fence);
+}

--- a/BOJ/1916.최소비용 구하기/1916_최소비용 구하기.cpp
+++ b/BOJ/1916.최소비용 구하기/1916_최소비용 구하기.cpp
@@ -1,0 +1,48 @@
+#include <iostream>
+#include <vector>
+#include <queue>
+#include <climits>
+
+using namespace std;
+
+int Dijkstra(int start, int end, vector <vector<pair<int, int>>> cost) {
+	//start to everywhere의 최소값.
+	vector <int> dist(cost.size() + 1, INT_MAX);
+	priority_queue<pair<int, int>> pq;
+	pq.push({ 0,start });
+	dist[start] = 0;
+	while (!pq.empty()) {
+		int mininum_cost = -pq.top().first;
+		int that_vertex = pq.top().second;
+		pq.pop();
+		if (mininum_cost > dist[that_vertex])
+			continue;
+		for (auto p : cost[that_vertex]) {
+			if (mininum_cost + p.first < dist[p.second]) {
+				dist[p.second] = mininum_cost + p.first;
+				pq.push({ -dist[p.second] ,p.second });
+			}
+		}
+	}
+	return dist[end];
+}
+
+int main() {
+	int N;
+	cin >> N;
+	vector <vector<pair<int, int>>> cost;
+	cost.resize(N + 1);
+	int M;
+	cin >> M;
+	int from_city;
+	int to_city;
+	int bus_cost;
+	for (int i = 0; i < M; i++) {
+		cin >> from_city >> to_city >> bus_cost;
+		cost[from_city].push_back({ bus_cost,to_city });
+	}
+	int res_from_city;
+	int res_to_city;
+	cin >> res_from_city >> res_to_city;
+	cout << Dijkstra(res_from_city, res_to_city, cost);
+}


### PR DESCRIPTION
**1**
출처 : 백준
https://www.acmicpc.net/problem/1725

**2**
input : 막대그래프
output : 가장 큰 직사각형 넒이

**3**
풀이 아이디어
종만북의 울타리 잘라내기와 동일한 문제입니다.
분할정복을 합니다. 3가지로 나누어서 분할정복합니다.
첫번째 경우, 중앙을 기준으로 왼쪽에 해가 위치하는 경우,
두번쨰 경우, 중앙을 기준으로 오른쪽에 해가 위치하는 경우,
세번째 경우, 중앙을 포함하여 해가 위치하는 경우.
base case의 경우는 히스토그램 막대기가 하나인경우입니다. 
stack으로도 풀수있다고하는데 알아봐야겠습니다.

**1**
출처 : 백준
https://www.acmicpc.net/problem/1916

**2**
input : N개의 도시 / M개의 버스
output : 최소거리비용

**3**
풀이 아이디어
한점에서 모든 정점까지의 최단거리를 구하고 도착지의 최단거리를 출력
다익스트라 알고리즘을 이용.
다익스트라는 ElogV의 시간복잡도를 가진다. 100,000 * log 1000 = 백만 이므로 제한시간 0.5초안에 가능.