### PR TITLE
[분할정복/페르마의소정리/이항계수]이항계수3 , [벨만포드]타임머신

### DIFF
--- a/BOJ/11401.이항계수 3/6047198844.cpp
+++ b/BOJ/11401.이항계수 3/6047198844.cpp
@@ -1,0 +1,31 @@
+#include <iostream>
+#include <vector>
+#define LL long long
+using namespace std;
+
+LL Factorial(int N,vector<LL> &memo) {
+	if (memo[N])
+		return memo[N];
+	return memo[N] = N * Factorial(N - 1, memo) % 1000000007;
+}
+
+LL divide_and_conquer(int A, int P) {
+	if (P == 1)
+		return A;
+	LL half = divide_and_conquer(A, P / 2) % 1000000007;
+	if (P % 2)
+		return ((half * half) % 1000000007 * A) % 1000000007;
+	return half * half % 1000000007;
+}
+
+int main() {
+	int N; int K;
+	cin >> N >> K;
+	vector<LL> memo(N + 1, 0);
+	memo[0] = memo[1] = 1;
+	LL N_fact = Factorial(N, memo);
+	LL K_fact = Factorial(K, memo);
+	LL N_minus_K_fact = Factorial(N - K, memo);
+	LL res = (N_fact * divide_and_conquer(K_fact, 1000000007 - 2) % 1000000007 * divide_and_conquer(N_minus_K_fact, 1000000007 - 2)) % 1000000007;
+	cout << res;
+}

--- a/BOJ/11657.타임머신/6047198844.cpp
+++ b/BOJ/11657.타임머신/6047198844.cpp
@@ -1,0 +1,52 @@
+#include <iostream>
+#include <vector>
+#include <climits>
+#define P pair<int,long long>
+#define INF INT_MAX
+#define LL long long
+using namespace std;
+
+void Bellman_ford(int N,vector <vector<P>> &adj) {
+	vector <LL> dist(N, INF);
+	dist[0] = 0;
+	bool infinite_loop = false;
+	for (int i = 0; i < N; i++) {
+		for (int u = 0; u < N; u++) {
+			for (auto p : adj[u]) {
+				int v = p.first;
+				LL cost = p.second;
+				if (dist[u] != INF && dist[v] > dist[u] + cost) {
+					dist[v] = dist[u] + cost;
+					if (i == N - 1)
+						infinite_loop = true;
+				}
+			}
+		}
+	}
+	if (infinite_loop) {
+		cout << -1;
+		return;
+	}
+
+	for (int i = 1; i < N; i++) {
+		if (dist[i] == INF)
+			cout << "-1";
+		else
+			cout << dist[i];
+		cout << "\n";
+	}
+}
+
+
+int main() {
+	int N, M;
+	cin >> N >> M;
+	vector <vector<P>> adj(N);
+	int A, B, C;
+	for (int i = 0; i < M; i++) {
+		cin >> A >> B >> C;
+		//출발 -> 도착 -> 비용
+		adj[A - 1].push_back({ B - 1,C });
+	}
+	Bellman_ford(N, adj);
+}


### PR DESCRIPTION
이항계수3
**1**
출처 : 백준
https://www.acmicpc.net/problem/11401

**2**
input : 조합
output : 이항계수

**3**
풀이 아이디어
조합 nCr = N! / K! (N-K)! 를 mod 1,000,000,007로 나눈값이 정답이다.
1,000,000,007은 소수.
K!(N-K)! mod 1,000,000,007 할수없다. 0이 나올수있기 때문에. 따라서 페르마의소정리를 사용한다.
K!(N-K)!를 a라고 하면. 페르마의 소정리에 의해서 a^P = a mod P이다.
따라서 a^P-2 = a^-1 mod P이다.
N! / K! (N-K)!는 N! * (K! (N-K)!)^  1,000,000,007-2 와같다
이후 과정은 팩토리얼과 분할정복으로 푼다.

타임머신
**1**
출처 : 백준
https://www.acmicpc.net/problem/11657

**2**
input : 정점과 간선 (음수간선포함)
output : 한정점에서 모든정점까지의 최소거리.

**3**
풀이 아이디어
기본 벨판-포드 알고리즘을 이용해서 풀었다. 음수간선이 존재할때 한정점에서 모든정점의 최소거리를 구할때 사용한다.
따라서 시간복잡도가 O(VE)임에도 사용한다.