### PR TITLE
[DP]삼각형 위의 최대 경로 / [DP] 최대 증가 부분 수열

### DIFF
--- a/알고스팟/삼각형 위의 최대 경로/6047198844.cpp
+++ b/알고스팟/삼각형 위의 최대 경로/6047198844.cpp
@@ -1,0 +1,34 @@
+#include <iostream>
+#include <vector>
+#include <algorithm>
+
+using namespace std;
+
+int dp(int y, int x,int N, vector <vector<int>> &triangle, vector <vector<int>>& memo) {
+	if (y == N - 1)
+		return triangle[y][x];
+	
+	int& res = memo[y][x];
+	if (res != -1)
+		return res;
+
+	return res = triangle[y][x] + max(dp(y + 1, x, N, triangle, memo), dp(y + 1, x + 1, N, triangle, memo));
+}
+
+int main() {
+	int C;
+	cin >> C;
+	while (C--) {
+		int N;
+		cin >> N;
+		vector <vector<int>> triangle(N, vector<int>(N));
+		vector <vector<int>> memo(N, vector<int>(N, -1));
+		for (int y = 0; y < N; y++) {
+			for (int x = 0; x <= y; x++) {
+				cin >> triangle[y][x];
+			}
+		}
+		cout << dp(0, 0, N, triangle, memo) << "\n";
+	}
+	
+}

--- a/알고스팟/최대 증가 부분 수열/6047198844.cpp
+++ b/알고스팟/최대 증가 부분 수열/6047198844.cpp
@@ -1,0 +1,32 @@
+#include <iostream>
+#include <vector>
+#include <algorithm>
+
+using namespace std;
+
+int lis(int idx, int N, vector <int> &seq, vector <int> &memo) {
+	int& res = memo[idx + 1];
+	if (res != -1)
+		return res;
+	res = 1;
+	for (int start = idx + 1; start < N; start++) {
+		if (idx == -1 || seq[idx] < seq[start])
+			res = max(res, 1 + lis(start, N, seq, memo));
+	}
+	return res;
+}
+
+int main() {
+	int C;
+	cin >> C;
+	while (C--) {
+		int N;
+		cin >> N;
+		vector <int> seq(N);
+		vector <int> memo(N + 1, -1);
+		for (int i = 0; i < N; i++) {
+			cin >> seq[i];
+		}
+		cout << lis(-1, N, seq, memo) - 1 << "\n";
+	}
+}


### PR DESCRIPTION
삼각형 위의 최대 경로
**1**
출처 : 알고스팟

**2**
input : 정수 삼각형
output : 최대합

**3**
풀이 아이디어
부분 집합의 최적해가 전체 집합의 최적해가 됩니다. 이를 최적 부분 구조라고 합니다.
이 문제는 최적 부분 구조를 생각하기 가장 간단한 문제입니다.
왜냐하면 memo[y][x]가 (x,y)에서 가장 큰 최대합이라고 할때. memo[y][x] = arr[y][x] + max (memo[y+1][x+1], memo[y+1][x]) 입니다. 이때 memo[y+1][x+1], memo[y+1][x]이 arr[y][x]와 관련이 없습니다. arr[y][x]가 무슨값을 가지던. memo[y+1][x+1]는 (x+1,y+1)에서의 부분 집합의 최적해고, memo[y+1][x]는 (x,y+1)에서의 부분 집합의 최적해입니다.  

최대 증가 부분 수열
**1**
출처 : 알고스팟

**2**
input : 수열
output : 최대 증가 부분 수열의 길이

**3**
풀이 아이디어
최적 부분 구조를 이용합니다. 이 역시 부분 집합의 최적해가 전채 집합의 최적해가 됩니다.
3 2 1 7 5 4 2 6 이라는 수열이 존재한다고 할때. memo[i]를 i에서의 최대 증가 부분 수열의 길이라고 합시다.
memo[i]는 max(memo[index[i]보다 큰 index[i+1,i+2...i+N-1]값])
이때 memo[i]의 index[i]가 memo[index[i]보다 큰 index[i+1,i+2...i+N-1]값에 영향을 주지 않습니다.
직관적으로 부분집합의 해로. 전채 집합의 최적해를 만들수있습니다.
