### PR TITLE
[LeetCode] Find Pivot Index

### DIFF
--- a/LeetCode/Array/Find_Pivot_Index/HyeonJeong.java
+++ b/LeetCode/Array/Find_Pivot_Index/HyeonJeong.java
@@ -1,0 +1,19 @@
+package LeetCode.Array.Find_Pivot_Index;
+
+class HyeonJeong {
+    public int pivotIndex(int[] nums) {
+        int len = nums.length;
+        for (int i = 0; i < len; i++) {
+            int left = 0, right = 0;
+            for (int j = 0; j < len; j++) { // 배열에서 기준 요소(nums[j])에 따라 양쪽 요소들의 합을 구함
+                if (j < i)
+                    left += nums[j];
+                else if (j > i)
+                    right += nums[j];
+            }
+            if (left == right)
+                return i;
+        }
+        return -1;
+    }
+}


### PR DESCRIPTION
배열에서 왼쪽과 오른쪽의 모든 숫자의 합이 같은 인덱스를 구하는 문제

풀이
1. 배열의 가장자리도 구하려는 인덱스가 될 수 있으므로 더해질 인덱스가 없는 경우에는 0을 가질 수 있도록 변수 선언
2. 기준이 될 인덱스는 제외시키고, 왼쪽과 오른쪽의 값이 구분되어 합이 누적될 수 있게 함

https://leetcode.com/problems/find-pivot-index/