### PR TITLE
[알고스팟] 타일링 방법의 수 세기 / [알고스팟] 삼각형 위의 최대 경로수 세기

### DIFF
--- a/알고스팟/삼각형 위의 최대 경로수 세기/6047198844.cpp
+++ b/알고스팟/삼각형 위의 최대 경로수 세기/6047198844.cpp
@@ -1,0 +1,56 @@
+#include <iostream>
+#include <vector>
+#include <algorithm>
+#include <cstring>
+
+using namespace std;
+
+int maxPathMemo[100][100];
+int pathNumMemo[100][100];
+int path[100][100];
+
+//n은 최대 y값.
+int MaxPath(int y, int x,int n) {
+	int &res = maxPathMemo[y][x];
+	if (y == n)
+		return path[y][x];
+	if (res != -1)
+		return res;
+	return res = path[y][x] + max(MaxPath(y + 1, x, n), MaxPath(y + 1, x + 1, n));
+}
+
+int PathNum(int y, int x,int n) {
+	int& res = pathNumMemo[y][x];
+	if (y == n)
+		return 1;
+	if (res != -1)
+		return res;
+
+	int leftMaxPath = MaxPath(y + 1, x, n);
+	int RightMaxPath = MaxPath(y + 1, x + 1, n);
+
+	if (leftMaxPath == RightMaxPath)
+		return res = PathNum(y + 1, x, n) + PathNum(y + 1, x + 1, n);
+	else if (leftMaxPath > RightMaxPath)
+		return res = PathNum(y + 1, x, n);
+	else
+		return res = PathNum(y + 1, x + 1, n);
+}
+
+int main() {
+	int C;
+	cin >> C;
+	int n;
+	while (C--) {
+		memset(maxPathMemo, -1, sizeof(maxPathMemo));
+		memset(pathNumMemo, -1, sizeof(pathNumMemo));
+		memset(path, -1, sizeof(path));
+		cin >> n;
+		for (int y = 0; y < n; y++) {
+			for (int x = 0; x <= y; x++) {
+				cin >> path[y][x];
+			}
+		}
+		cout << PathNum(0, 0, n - 1) << "\n";
+	}
+}

--- a/알고스팟/타일링 방법의 수 세기/6047198844.cpp
+++ b/알고스팟/타일링 방법의 수 세기/6047198844.cpp
@@ -1,0 +1,26 @@
+//1000000007
+#include <iostream>
+#include <vector>
+#include <cstring>
+
+using namespace std;
+
+int memo[101];
+
+long long dp(int n) {
+	if (n == 1 || n == 2)
+		return n;
+	if (memo[n] != -1)
+		return memo[n] % 1000000007;
+	return memo[n] = (dp(n - 1) % 1000000007 + dp(n - 2) % 1000000007) % 1000000007;
+}
+
+int main() {
+	int C,N;
+	cin >> C;
+	memset(memo, -1, sizeof(memo));
+	while (C--) {
+		cin >> N;
+		cout << dp(N) << "\n";
+	}
+}


### PR DESCRIPTION
**1**
출처 : 알고스팟

**2**
input : 타일 수
output : 만들수있는 타일링 방법의 수

**3**
풀이 아이디어
DP를 사용해서 풀었습니다.
2X2 타일의 가로길이를 n이라고 하면 n=1일때 1이 나오고. n==2일때는 2가 나옵니다.
나머지는 dp(n) = dp(n-1) + dp(n-2)로 처리가 되고요. 풀었던 문제였습니다.

**1**
출처 : 알고스팟

**2**
input : 경로
output : 최대 경로 개수 세기

**3**
풀이 아이디어
DP가 두번 이루어 집니다.
먼저 각 경로에서의 최대 값을 구합니다.
아래의 경우는
9
5 7
1 3 2
3 5 5 6
아래의 경우가 됩니다.
24
13 15
6 8 8
3 5 5 6
여기 까지는 저번에 풀이했었던 내용입니다.
여기서 최대 경로 개수를 세야합니다.
우선 맨 아래의 경우에는 무조건 경로 개수가 1입니다.
현재 경로의 수는 세가지 경우의 수의 합입니다.
left를 y+1, x의 최대 값, right 를 y+1, x+1의 최대값이라고 할때
left == right 인경우
결과는 양쪽 경로의 합입니다.
left < right 인경우
결과는 오른쪽 경로의 합입니다.
left > right 인경우
결과는 왼쪽 경로의 합입니다.
