### PR TITLE
[DP]폴리오미노

### DIFF
--- a/알고스팟/폴리오미노/6047198844.cpp
+++ b/알고스팟/폴리오미노/6047198844.cpp
@@ -1,0 +1,32 @@
+#include <iostream>
+#include <cstring>
+
+#define ll long long
+using namespace std;
+
+long long memo[101][101];
+
+ll dp(int used, int remain) {
+	if (remain == 0)
+		return 1;
+	ll &res = memo[used][remain];
+	if (res != -1)
+		return res;
+	res = 0;
+	for (int cnt = 1; cnt <= remain; cnt++) {
+		int mul = used ? (used + cnt - 1) : 1;
+		res += (mul * dp(cnt, remain - cnt)% 10000000);
+	}
+	return res % 10000000;
+}
+
+int main() {
+	int C;
+	cin >> C;
+	int n;
+	memset(memo, -1, sizeof(memo));
+	while (C--) {
+		cin >> n;
+		cout << dp(0, n) << "\n";
+	}
+}


### PR DESCRIPTION
**1**
출처 : 알고스팟

**2**
input : 사각형의 수
output : 정사각형의 수

**3**
풀이 아이디어
dp로 짜봤습니다. 제가 푼게 좀 놀랍네요. 원래 난이도 중문제는 풀지도못했었는데 처음으로 풀어서 신기하기도하고..
여튼 제 아이디어는
dp(현재행에서 선택한 사각형의 개수, 남아있는 사각형의 개수)
종만북에서 배운것처럼 최대한 인자를 줄였습니다. 현재행에서 선택한 사각형의 개수는 다음행에 선택한 사각형과 함께 쓰이고, 남아있는 사각형의 갯수는 당연히 사각형이 모두 소진됬을시에 종료해야하기때문에 존재합니다. 
사각형의 초기수가 4이므로
dp(0,4)에서 시작합니다.
dp(0,4) = dp(1,3) + dp(2,2) + dp(3,1) + dp(4,0)
dp(1,3)은
dp(1,3) = 1* dp(1,2) + 2* dp(2,1) + 3* dp(3,0)
앞에 곱셈이 붙었습니다. 왜일까요.
1과 2는 그 자체가 2가지의 경우의 수를 만들고
1과 3는 그 자체가 3가지의 경우의 수를 만듭니다.
무슨말이냐면
ㅁ
ㅁㅁ

    ㅁ
ㅁㅁ

2가지

ㅁ
ㅁㅁㅁ
   ㅁ
ㅁㅁㅁ
       ㅁ
ㅁㅁㅁ

3가지.

이것은. 현재선택된 사각형의 갯수 + 다음행에 선택할 사각형의 갯수 -1 이됩니다. 그림을 그리니 규칙이 생겼습니다.
한 행에서 2개의 사각형 묶음을 고를수없습니다. 따라서 한행은 한묶음의 사각형으로 결정해야합니다. 그래서 하나의 숫자만 택하는것이고요. 