### PR TITLE
[DP]두니발 박사의 탈옥 / [DP]전깃줄

### DIFF
--- a/BOJ/2565.전깃줄/6047198844.cpp
+++ b/BOJ/2565.전깃줄/6047198844.cpp
@@ -1,0 +1,39 @@
+#include <iostream>
+#include <vector>
+#include <algorithm>
+
+using namespace std;
+
+int cache[100];
+
+int dp(vector<int>& vt, int idx,int size) {
+	int& res = cache[idx];
+	if (res)
+		return res;
+	res = 1;
+	for (int dx = 1; idx + dx <= size; dx++) {
+		if (vt[idx] < vt[idx + dx]) {
+			res = max(res, 1 + dp(vt, idx + dx, size));
+		}
+	}
+	return res;
+}
+
+int main() {
+	int N;
+	cin >> N;
+	pair <int, int> p;
+	vector<pair<int, int>> vt;
+	while (N--) {
+		cin >> p.first >> p.second;
+		vt.push_back(p);
+	}
+	sort(vt.begin(), vt.end());
+	int size = vt.size();
+	vector <int> lis;
+	lis.push_back(-1);
+	for (int i = 0; i < size; i++) {
+		lis.push_back(vt[i].second);
+	}
+	cout << size - (dp(lis, 0, size) - 1);
+}

--- a/알고스팟/두니발 박사의 탈옥/6047198844.cpp
+++ b/알고스팟/두니발 박사의 탈옥/6047198844.cpp
@@ -1,0 +1,53 @@
+#include <iostream>
+#include <vector>
+using namespace std;
+
+double cache[51][101];
+
+double findDuni(int here, int where,int remDay,vector<vector<int>> &road) {
+	if (remDay == 0)
+		return here == where;
+	double& res = cache[here][remDay];
+	if (res != 0)
+		return res;
+
+	int roadNum = road[here].size();
+	double mul = 1 / (double)roadNum;
+	for (int i = 0; i < roadNum; i++) {
+		res += (mul) * findDuni(road[here][i], where, remDay - 1, road);
+	}
+	return res;
+}
+
+int main() {
+	cout.precision(10);
+	int c;
+	cin >> c;
+	while (c--) {
+		//마을 , 지금까지 지난 일수, 교도소가 있는 마을의 번호
+		int n, d, p;
+		cin >> n >> d >> p;
+		vector <vector<int>> road(n);
+		int to_town;
+		int from_town;
+		int temp;
+		for (int i = 0; i < n; i++) {
+			for (int j = 0; j < n; j++) {
+				cin >> temp;
+				if (temp)
+					road[i].push_back(j);
+			}
+		}
+		int t;
+		cin >> t;
+		while (t--) {
+			int q;
+			cin >> q;
+			for (int i = 0; i < n; i++)
+				for (int j = 0; j <= d; j++)
+					cache[i][j] = 0;
+			cout << findDuni(p, q, d, road) << " ";
+		}
+		cout << "\n";
+	}
+}


### PR DESCRIPTION
두니발 박사의 탈옥
**1**
출처 : 알고스팟

**2**
input : 감옥의 위치 , 경로, 지정동네
output: 지정 동네에 두니발 박사가 있을 확률
**3**
풀이 아이디어
드디어 종만북8장 문제를 꾸역꾸역 다풀엇네요. 하지만 완벽히 소화하려면 시간이 더 필요할것같습니다. 확실히 어려운 책인것같습니다. 숨겨진 의미가 많아서 읽을수록 배우는게 있습니다. 정리한 내용들은 스터디 저장소에 있습니다.
여튼 이 문제에 DP를 사용할수있었던 이유는
문제를 분할했을때 중복되는 문제가 존재하고 최적 부분 구조가 성립하기 때문이였는데요.
현재 동네에서 두니발 박사가 있을 확률은 이전동네와 관련이 없기때문에 가능했습니다. 따라서 그냥 현 위치에서 한 지점까지 갈확률에 그 지점에서 남은 기간동안 두니발 박사를 잡을 확률을 곱한것들의 모든 합이 정답이였네요.

전깃줄
**1**
출처 : 백준

**2**
input : 전깃줄
output : 끊어야하는 전깃줄의 최소수
**3**
풀이 아이디어
제일 긴 부분증가수열의 길이가 전깃줄을 가장 안끊어먹는(?) 방법입니다.
총길이 - 긴 부분증가수열의 길이하면 끊어야하는 전기줄의 개수를 얻게됩니다.