### PR TITLE
[DP]울타리 잘라내기 2

### DIFF
--- a/알고스팟/울타리 잘라내기 2/6047198844.cpp
+++ b/알고스팟/울타리 잘라내기 2/6047198844.cpp
@@ -1,0 +1,58 @@
+#include <iostream>
+#include <vector>
+#include <stack>
+#include <algorithm>
+
+using namespace std;
+
+///미션 : 스택을 이용한다.
+// 내가 하려고 하는게 무엇인가.
+// 스택을 이용해서 푼다. 구하려는것은 각각의 판자가 만들수있는 최대 사각형의 크기이다.
+// 다시말해서 한 판자가 자신을 꼭 포함하면서 만들수있는 최대 사각형의 크기이다.
+// 그 말인 즉슨 자신보다 작은 판자가 양옆으로 나오는 순간 최대 사각형의 크기를 구할수있다는 뜻이다.
+// 한쪽으로만 나왔을 경우에는 구할수가없다. 한계를 모르기 때문이다.
+// 아직 값을 구하지못한 사각형을 스택에 넣는다고 생각하자.
+
+int fence_stack(vector<int> &height) {
+	
+	height.push_back(0);
+	int N = height.size();
+
+	stack <int> st;
+	int res = 0;
+
+	for (int idx = 0; idx < N; idx++) {
+		//스택이 비엇다는것은 비교가 불가능함을 의미한다.
+		//while문은 스택에 남아있는 판자들을 확인하면서 right를 정해줄수있는지 판단한다.
+		while (!st.empty()&&height[st.top()]>=height[idx]) {
+			int h = height[st.top()];
+			st.pop();
+			int width = -1;
+			if (st.empty()) {
+				width = idx;
+			}
+			else {
+				int left = st.top();
+				width = idx - left - 1;
+			}
+			res = max(res, h * width);
+		}
+		//right값이 정해지지 않았다. 따라서 스택에 넣는다.
+		st.push(idx);
+	}
+	return res;
+}
+
+int main() {
+	int C;
+	cin >> C;
+	while (C--) {
+		int N;
+		cin >> N;
+		vector<int> height(N);
+		for (int i = 0; i < N; i++)
+			cin >> height[i];
+		
+		cout << fence_stack(height) << "\n";
+	}
+}


### PR DESCRIPTION
**1**
출처 : 알고스팟

**2**
input : 판자 높이
output : 판자로 만들수있는 최대 크기의 사각형

**3**
풀이 아이디어
이전에 분할과 정복으로 풀었던 문제인데요 그때도 접근이 처음이라 어려웠습니다.
이번에는 스위핑 알고리즘과 스택을 이용해서 풀었습니다. 스위핑 알고리즘은 아직 종만북에서 공부를 안한 단계라 확실하게는 모릅니다. 이름만 들으면 하나씩 처리할때 조건에 맞으면 쓸어가서 그런가하기도 하고 여튼 이 방법이 스위핑 알고리즘이라고 합니다. 

모든 판자에 있어서 i번 판자의 최대 사각형을 구하는 것을 목표로 합니다. 현재 판자의 최대 사각형이란 현재 판자를 항상 포함해서 만들수있는 최대 사각형이라는 뜻입니다. 그렇다는것은 left와 right가 현재 판자의 최대 사각형 밖에 있는 사각형중 가장 가까운 사각형. 즉 , 경계라고 쳤을때 현재 판자보다 낮은 판자가 경계가 됩니다. 이것을 하나하나 해서 너비를 구하고 높이를 곱해서 넒이를 구하는 방식으로 구하면 O(n^2)이 나오고 이것은 분할 정복보다 비효율적입니다.
이걸 스택을 이용해서 O(N) 시간에 구현할수있습니다.
우선 스택에 길이가 0이고 인덱스 번호가 -1인 판자가 있다고 가정합니다. 이 상황은 스택이 empty일때를 의미합니다.
스택에 들어가는것은 left값은 정해졌는데 right값이 정해지지 않은 판자입니다.
right값은 언제 정해질까요? 바로 스택의 top값보다 현재 판자가 같거나 작을때 정해집니다.
스택의 top보다 현재 판자가 크다는것은 스택의 top의 right가 정해지지 않았다는 뜻입니다. 자신보다 현재 판자가 크기때문에 확장이 가능합니다.
스택의 top보다 현재 판자와 같다는것은 스택의 top의 right를 현재 판자로 생각해도 좋습니다. 원래는 아닌데 현재 판자가 구하는 넓이가 결국에는 스택의 top이 구하는 넒이와 같기 때문에 그냥 여기서 처리해준다고 생각하면 됩니다.
스택의 top보다 현재 판자가 작다는것은 현재 판자가 스택의 right라는 뜻입니다.
스택의 right를 구하면 현재 스택에서 지우고 while문을 돌면서 현재 판자가 스택의 top의 right인지 판단을 해야합니다.
현재 판자는 stack의 나머지 부분에 대하여 right일 가능성도 있기 때문입니다.
스택에 쌓이는것은 높이가 오름차순으로 쌓입니다. 그렇지않다는것은 모순입니다. right값이 정해지기 때문입니다.
마지막 판자의 길이는 0으로 설정합니다. 마지막 판자의 길이가 0이면 무조건 stack이 날라갑니다. 0과 같거나 작은 판자의 높이는 없기 때문입니다.