### PR TITLE
[brute-force]체스판 다시 칠하기 / [tree]트리 순회 순서 변경 / [DP] 가장 큰 증가 부분 수열

### DIFF
--- a/BOJ/1018.체스판 다시 칠하기/6047198844.cpp
+++ b/BOJ/1018.체스판 다시 칠하기/6047198844.cpp
@@ -1,0 +1,61 @@
+/*
+문제
+지민이는 자신의 저택에서 MN개의 단위 정사각형으로 나누어져 있는 M*N 크기의 보드를 찾았다. 
+어떤 정사각형은 검은색으로 칠해져 있고, 나머지는 흰색으로 칠해져 있다. 지민이는 이 보드를 잘라서 8*8 크기의 체스판으로 만들려고 한다.
+
+체스판은 검은색과 흰색이 번갈아서 칠해져 있어야 한다. 
+구체적으로, 각 칸이 검은색과 흰색 중 하나로 색칠되어 있고, 변을 공유하는 두 개의 사각형은 다른 색으로 칠해져 있어야 한다.
+따라서 이 정의를 따르면 체스판을 색칠하는 경우는 두 가지뿐이다. 하나는 맨 왼쪽 위 칸이 흰색인 경우, 하나는 검은색인 경우이다.
+
+보드가 체스판처럼 칠해져 있다는 보장이 없어서, 지민이는 8*8 크기의 체스판으로 잘라낸 후에 몇 개의 정사각형을 다시 칠해야겠다고 생각했다.
+당연히 8*8 크기는 아무데서나 골라도 된다. 지민이가 다시 칠해야 하는 정사각형의 최소 개수를 구하는 프로그램을 작성하시오.
+
+입력
+첫째 줄에 N과 M이 주어진다. N과 M은 8보다 크거나 같고, 50보다 작거나 같은 자연수이다. 둘째 줄부터 N개의 줄에는 보드의 각 행의 상태가 주어진다. B는 검은색이며, W는 흰색이다.
+
+출력
+첫째 줄에 지민이가 다시 칠해야 하는 정사각형 개수의 최솟값을 출력한다.
+*/
+#include <iostream>
+#include <algorithm>
+
+using namespace std;
+
+char board[50][50];
+int N;
+int M;
+
+int brute_force(int y, int x,bool flag) {
+	int res = 0;
+	//black 이면 false, white면 true 
+	for (int dy = 0; dy < 8; dy++) {
+		for (int dx = 0; dx < 8; dx++) {
+			if (flag) {
+				if (board[y + dy][x + dx] != 'W')
+					res++;
+			}
+			else {
+				if (board[y + dy][x + dx] != 'B')
+					res++;
+			}
+			flag = !flag;
+		}
+		flag = !flag;
+	}
+	if(flag)
+		res = min(res, brute_force(y, x, false));
+	return res;
+}
+
+int main() {
+	cin >> N >> M;
+	for (int y = 0; y < N; y++)
+		for (int x = 0; x < M; x++)
+			cin >> board[y][x];
+	int res = 100000;
+	for (int y = 0; y + 7 < N; y++)
+		for (int x = 0; x + 7 < M; x++)
+			res = min(res,brute_force(y,x,true));
+	cout << res;
+}
+

--- a/BOJ/11055.가장 큰 증가 부분 수열/6047198844.cpp
+++ b/BOJ/11055.가장 큰 증가 부분 수열/6047198844.cpp
@@ -1,0 +1,31 @@
+#include <iostream>
+#include <algorithm>
+using namespace std;
+
+int arr[1001] = {};
+int memo[1001] = {};
+
+int bottomup_dp(int n)
+{
+	int ans = 0;
+	//memo[1] = arr[1];
+	for (int i = 1; i <= n; i++)
+	{
+		for (int j = 0; j < i; j++)
+			if (arr[i] > arr[j])
+				memo[i] = max(memo[i], memo[j] + arr[i]);
+	}
+	ans = *max_element(&memo[1], &memo[1] + n);
+	return ans;
+}
+
+int main()
+{
+	int n;
+	cin >> n;
+
+	for (int i = 1; i <= n; i++)
+		cin >> arr[i];
+
+	cout << bottomup_dp(n);
+}

--- a/알고스팟/트리 순회 순서 변경/6047198844.cpp
+++ b/알고스팟/트리 순회 순서 변경/6047198844.cpp
@@ -1,0 +1,48 @@
+#include <iostream>
+#include <vector>
+#include <algorithm>
+
+using namespace std;
+
+vector <int> slice(const vector <int>& order, int begin, int end) {
+	return vector<int>(order.begin() + begin, order.begin() + end);
+}
+
+//후위 순회를 출력하는 함수.
+//preorder은 root를 알려준다.
+//inorder은 preorder에서 얻은 root를 기준으로 좌측 서브 트리와 우측 서브 트리를 구할수있게 한다
+void printPost(const vector <int>& preorder, const vector <int>& inorder) {
+	if (preorder.empty())
+		return;
+	int treeSize = preorder.size();
+	int root = preorder[0];
+	const int L = find(inorder.begin(), inorder.end(), root) - inorder.begin();
+	//좌측 서브 트리 후위 방문
+	printPost(slice(preorder, 1, L + 1), slice(inorder, 0, L));
+	//우측 서브 트리 후위 방문
+	printPost(slice(preorder, L + 1, treeSize), slice(inorder, L + 1, treeSize));
+	//이제 루트 출력
+	cout << root << " ";
+}
+
+int main() {
+	int C;
+	cin >> C;
+	while (C--) {
+		int N;
+		int num;
+		cin >> N;
+		vector <int> preorder;
+		for (int i = 0; i < N; i++) {
+			cin >> num;
+			preorder.push_back(num);
+		}
+		vector <int> inorder;
+		for (int i = 0; i < N; i++) {
+			cin >> num;
+			inorder.push_back(num);
+		}
+		printPost(preorder, inorder);
+		cout << "\n";
+	}
+}


### PR DESCRIPTION
체스판 다시 칠하기
**1**
출처 : 백준

**2**
input : 체스판
output : 잘못된 체스판의 칸의 개수

**3**
풀이 아이디어
브루트 포스를 쓰게 된 이유는
N과 M이 최대 50을 가질수있고 N과 M을 다 돈다고 가정해도 2500개의 채스판을 보게됩니다.
한 체스판은 64개의 칸으로 이루어져있습니다. 한 체스판을 두가지 경우로 보게됩니다 (WB 인 경우와 BW인 경우)
2500 * 64 * 2 해도 1억이 안나옵니다.
쉬운문제인데 시작하는 칸에 맞추어 정사각형 개수를 세었더니 틀렸었네요. 오래전에 못풀었던 문제인데 쉽게 풀었습니다.

트리 순회 순서 변경
**1**
출처 : 알고스팟

**2**
input : 전위순회 , 중위순회
output : 후위순회 출력값

**3**
풀이 아이디어
자료구조 시간에 배운 내용인데 손으로만 풀어봤습니다. 코딩으로 해본적은 처음입니다.
트리의 재귀적 성질을 이용합니다.
트리는 root와 subtree로 나눌수있습니다. 그리고 그것은 재귀적입니다. subtree에도 root가 존재하기 때문입니다.
root의 좌측 subtree 후위출력.
root의 우측 subtree 후위출력.
root 출력을 하게 되면 최종적으로 후위출력을 할수있다는것을 할수있습니다.  