### PR TITLE
[BFS]인구이동 / [완전탐색]분해합

### DIFF
--- a/BOJ/16234.인구 이동/6047198844.cpp
+++ b/BOJ/16234.인구 이동/6047198844.cpp
@@ -1,0 +1,81 @@
+#include <iostream>
+#include <vector>
+#include <queue>
+#include <math.h>
+
+using namespace std;
+
+const int dy[4] = { -1,+1,0,0 };
+const int dx[4] = { 0,0,-1,+1 };
+
+bool rangeCheck(int y, int x, int N) {
+	if (0 <= y && y < N &&
+		0 <= x && x < N)
+		return true;
+	return false;
+}
+
+int bfs(vector<vector<int>> arr,int N,int L, int R) {
+	int cnt = 0;
+	while (1) {
+		bool flag = false;
+		vector < vector < bool >> check(N, vector<bool>(N));
+		for (int y = 0; y < N; y++) {
+			for (int x = 0; x < N; x++) {
+				if (!check[y][x]) {
+					queue <pair<int, int>> q;
+					queue <pair<int, int>> cq;
+					check[y][x] = true;
+					q.push({ y,x });
+
+					int sum = arr[y][x];
+					while (!q.empty()) {
+						int y = q.front().first;
+						int x = q.front().second;
+						q.pop();
+
+						for (int d = 0; d < 4; d++) {
+							int iy = y + dy[d];
+							int ix = x + dx[d];
+							if (rangeCheck(iy, ix, N) && !check[iy][ix]) {
+								int sub = abs(arr[y][x] - arr[iy][ix]);
+								if (L <= sub && sub <= R) {
+									q.push({ iy,ix });
+									cq.push({ iy,ix });
+									sum += arr[iy][ix];
+									check[iy][ix] = true;
+								}
+							}
+						}
+					}
+					int avg;
+					if (cq.size()) {
+						cq.push({ y,x });
+						avg = sum / cq.size();
+						flag = true;
+					}
+					while (!cq.empty()) {
+						int y = cq.front().first;
+						int x = cq.front().second;
+						cq.pop();
+						arr[y][x] = avg;
+					}
+				}
+			}
+		}
+		if (flag)
+			cnt++;
+		else
+			return cnt;
+	}
+}
+
+int main() {
+	int N, L, R;
+	cin >> N >> L >> R;
+	vector<vector<int>> arr(N, vector<int>(N));
+	for (int y = 0; y < N; y++)
+		for (int x = 0; x < N; x++)
+			cin >> arr[y][x];
+	cout << bfs(arr, N, L, R);
+}

--- a/BOJ/2231.분해합/6047198844.cpp
+++ b/BOJ/2231.분해합/6047198844.cpp
@@ -1,0 +1,25 @@
+#include <iostream>
+
+using namespace std;
+
+int brute_force(int N){
+    for(int i = 1; i <= 1000000; i++){
+        int res = i;
+        int temp = i;
+        while(temp){
+            res += temp % 10;
+            temp /= 10;
+        }
+        if(res==N)
+            return i;
+    }
+    return 0;
+}
+
+int main()
+{
+    int N;
+    cin >> N;
+    cout << brute_force(N);
+    return 0;
+}


### PR DESCRIPTION
인구이동
**1**
출처 : 백준

**2**
input : 인구수
output : 인구 이동수

**3**
풀이 아이디어
조금 복잡한 BFS같네요.
한번 순회할때마다 인구이동이 가능한 그룹을 찾아서 해당 그룹을 바로 바꿔줍니다. **중요한것은 바꾼 그룹에 속한 원소들은 한번 순회하는 동안 다시 바뀌어서는 안됩니다.** 즉, 방문처리를 해줌으로써 다시 방문하지 못하도록 합니다.
순회했음에도 불구하고 그룹을 하나도 못찾았을때는 인구이동이 없는것이므로 정답을 반환합니다.

분해합
**1**
출처 : 백준

**2**
Input : N
Output : 최소생성자

**3**
풀이 아이디어 
각 숫자의 합을 N까지 더한다.
1000000 × 7 < 1억