### PR TITLE
[BOJ]30 / [트립]삽입 정렬 뒤집기 / [분할정복] 팬미팅

### DIFF
--- a/BOJ/10610.30/6047198844.cpp
+++ b/BOJ/10610.30/6047198844.cpp
@@ -1,0 +1,15 @@
+#include <stdio.h>
+#include <iostream>
+
+using namespace std;
+int s, k, n[10];
+int main() {
+	while (~scanf("%1d", &k))
+		n[k]++, s += k;
+	if (s % 3 || !n[0])
+		printf("-1");
+	else
+		for (int i = 9; i >= 0; i--)
+			while (n[i]--)
+				printf("%d", i);
+}

--- a/알고스팟/삽입 정렬 뒤집기/6047198844.cpp
+++ b/알고스팟/삽입 정렬 뒤집기/6047198844.cpp
@@ -1,0 +1,120 @@
+#include <iostream>
+#include <ctime>
+#include <cstdlib>
+using namespace std;
+int C, N, A[50001], shifted[50001];
+
+struct Node {
+	int key;
+	int priority, size;
+	Node* left, * right;
+	Node(const int& _key) : key(_key), priority(rand()), size(1), left(NULL), right(NULL) {}
+	void setLeft(Node* newLeft) { left = newLeft; calcSize(); }
+	void setRight(Node* newRight) { right = newRight; calcSize(); }
+	void calcSize() {
+		size = 1;
+		if (left) size += left->size;
+		if (right) size += right->size;
+	}
+};
+
+typedef pair<Node*, Node*> NodePair;
+NodePair split(Node* root, int key) {
+	if (root == NULL) return NodePair(NULL, NULL);
+	if (root->key < key) {
+		NodePair rs = split(root->right, key);
+		root->setRight(rs.first);
+		return NodePair(root, rs.second);
+	}
+	else {
+		NodePair ls = split(root->left, key);
+		root->setLeft(ls.second);
+		return NodePair(ls.first, root);
+	}
+}
+
+Node* insert(Node* root, Node* node) {
+	if (root == NULL) return node;
+	if (root->priority < node->priority) {
+		NodePair splitted = split(root, node->key);
+		node->setLeft(splitted.first);
+		node->setRight(splitted.second);
+		return node;
+	}
+	else if (node->key < root->key) {
+		root->setLeft(insert(root->left, node));
+	}
+	else
+		root->setRight(insert(root->right, node));
+	return root;
+}
+
+Node* merge(Node* a, Node* b) {
+	if (a == NULL) return b;
+	if (b == NULL) return a;
+	if (a->priority < b->priority) {
+		b->setLeft(merge(a, b->left));
+		return b;
+	}
+	else {
+		a->setRight(merge(a->right, b));
+		return a;
+	}
+}
+
+Node* erase(Node* root, int key) {
+	if (root == NULL) return root;
+	if (root->key == key) {
+		Node* ret = merge(root->left, root->right);
+		delete root;
+		return ret;
+	}
+	if (key < root->key)
+		root->setLeft(erase(root->left, key));
+	else
+		root->setRight(erase(root->right, key));
+	return root;
+}
+
+Node* kth(Node* root, int k) {
+	int leftSize = 0;
+	if (root->left != NULL) leftSize = root->left->size;
+	if (k <= leftSize) return kth(root->left, k);
+	if (k == leftSize + 1) return root;
+	return kth(root->right, k - leftSize - 1);
+}
+int countLessThan(Node* root, int key)
+{
+	if (root == NULL)
+		return 0;
+	if (root->key >= key)
+		return countLessThan(root->left, key);
+	int ls = (root->left ? root->left->size : 0);
+	return ls + 1 + countLessThan(root->right, key);
+}
+
+void solve() {
+	Node* candidate = NULL;
+	for (int i = 0; i < N; i++)
+		candidate = insert(candidate, new Node(i + 1));
+	for (int i = N - 1; i >= 0; i--) {
+		int large = shifted[i];
+		Node* k = kth(candidate, i + 1 - large);
+		A[i] = k->key;
+		candidate = erase(candidate, k->key);
+	}
+}
+
+int main()
+{
+	cin >> C;
+	while (C--) {
+		cin >> N;
+		for (int i = 0; i < N; i++)
+			cin >> shifted[i];
+		solve();
+		for (int i = 0; i < N; i++)
+			cout << A[i] << " ";
+		cout << endl;
+	}
+}

--- a/알고스팟/팬미팅/6047198844.cpp
+++ b/알고스팟/팬미팅/6047198844.cpp
@@ -1,0 +1,100 @@
+#include <iostream>
+#include <vector>
+#include <algorithm>
+
+using namespace std;
+
+//a와 b를 곱한값을 리턴한다.
+vector <int> multiply(const vector<int>& a, const vector<int>& b) {
+	int an = a.size();
+	int bn = b.size();
+	vector<int> res(an + bn + 1, 0);
+	for (int i = 0; i < an; i++) {
+		for (int j = 0; j < bn; j++) {
+				res[i + j] += a[i] * b[j];
+		}
+	}
+	return res;
+}
+
+//a가 항상 크다고 가정한다. a에서 b를 뺀다.
+void subFrom(vector<int>& a, vector<int>& b) {
+	int bn = b.size();
+	for (int i = 0; i < bn; i++)
+		a[i] -= b[i];
+}
+
+//a + b * (10^k)
+void addTo(vector<int>& a, vector<int>& b, int k) {
+	//vector<int> bm(k);
+	//int bn = b.size();
+	//for (int i = 0; i < bn; i++)
+	//	bm.push_back(b[i]);
+
+	//while (a.size() < bm.size())
+	//	a.push_back(0);
+
+	//for (int i = 0; i < bm.size(); i++)
+	//	a[i] += bm[i];
+
+	int length = b.size();
+	a.resize(max(a.size(), b.size() + k));
+	for (int i = 0; i < length; i++)
+		a[i + k] += b[i];
+}
+
+vector<int> karatsuba(const vector<int>& a, const vector<int>& b) {
+	int an = a.size();
+	int bn = b.size();
+	if (an < bn) karatsuba(b, a);
+	if (an == 0 || bn == 0) return vector<int>();
+	if (an <= 50) return multiply(a, b);
+	int half = an / 2;
+	vector<int> a0(a.begin(), a.begin() + half);
+	vector<int> a1(a.begin() + half, a.end());
+
+	vector<int> b0(b.begin(), b.begin() + min<int>(bn, half));
+	vector<int> b1(b.begin() + min<int>(bn, half), b.end());
+
+	vector<int> z0 = karatsuba(a1, b1);
+	vector<int> z1 = karatsuba(a0, b0);
+	addTo(a1, a0, 0);
+	addTo(b1, b0, 0);
+	vector<int> z2 = karatsuba(a1, b1);
+	subFrom(z2, z0);
+	subFrom(z2, z1);
+
+	vector<int> res;
+	addTo(res, z0, half + half);
+	addTo(res, z2, half);
+	addTo(res, z1, 0);
+	return res;
+}
+
+int main() {
+	int C;
+	cin >> C;
+	while (C--) {
+		string A;
+		string B;
+		cin >> A >> B;
+
+		int N = A.size();
+		vector<int> group(N);
+		for (int i = 0; i < N; i++)
+			group[i] = (A[N - 1 - i] == 'M');
+
+		int M = B.size();
+		vector<int> fan(M);
+		for (int i = B.size() - 1; i >= 0; i--)
+			fan[i] = (B[i] == 'M');
+
+		vector<int> res = karatsuba(group, fan);
+		int cnt = 0;
+		//맴버의수는 항상 팬의 수 이하이다.
+		for (int i = N - 1; i < M; i++)
+			if (!res[i])
+				cnt++;
+		cout << cnt << "\n";
+	}
+}


### PR DESCRIPTION
30
**1**
출처 : 백준

**2**

input : 수
output : 30의 배수가 되는수 / -1

**3**
scanf("%1d",&n)은 EOF인 경우 -1을 반환합니다. 따라서 ~연산을 할경우 0이됩니다.

삽입 정렬 뒤집기
**1**
출처 : 알고스팟

**2**
input : 왼쪽으로 몇 칸이나 이동했는가.
output : 원래의 수열

**3**
풀이 아이디어
원래의 수열로 만드는 알고리즘은 생각하기 어렵지 않습니다.
1부터 N까지의 수들 중에서 K번째 원소를 찾고 해당원소를 삭제하면 되는 문제이기 때문입니다.
문제는 이것을 저장하는 자료구조를 어떻게 선정할것인지가 문제입니다.
배열로 할경우 삭제에 있어서 O(N),
연결리스트로 할경우 K번째 원소를 찾는데 O(N)이기때문에 N번 삭제/찾는데 있어서 각각 O(N^2)이므로 둘다 적합하지는 않습니다. 
이진 검색트리가 k번째 원소가 무엇인지를 찾고, 삭제하는 작업을 수행하는데 빠릅니다.
set은 k번째 원소를 찾는 기능을 제공하지않습니다. 따라서 트립을 만들어서 사용했습니다. 

팬미팅
**1**
출처 : 알고스팟

**2**
input : 아이돌그룹 / 팬
output : 전체가 포옹한 경우

**3**
풀이 아이디어
카라츠바 곱셈법을 이용합니다. 상당히 까다롭고 시간도 빡빡합니다. 